### PR TITLE
one minor typo change, plus support for Guid

### DIFF
--- a/CLAP/Exceptions.cs
+++ b/CLAP/Exceptions.cs
@@ -131,7 +131,7 @@ namespace CLAP
         public Type Type { get; private set; }
 
         public TypeConvertionException(string value, Type type, Exception inner)
-            : base("'{0}' connot be converted to {1}".FormatWith(value, type), inner)
+            : base("'{0}' cannot be converted to {1}".FormatWith(value, type), inner)
         {
             Value = value;
             Type = type;

--- a/CLAP/Parser.cs
+++ b/CLAP/Parser.cs
@@ -513,6 +513,10 @@ namespace CLAP
                 {
                     return Enum.Parse(type, value);
                 }
+                else if (type == typeof(Guid))
+                {
+                    return new Guid(value);
+                }
                 else
                 {
                     return Convert.ChangeType(value, type);

--- a/CLAP/Parser.cs
+++ b/CLAP/Parser.cs
@@ -515,7 +515,7 @@ namespace CLAP
                 }
                 else if (type == typeof(Guid))
                 {
-                    return new Guid(value);
+                    return (String.IsNullOrEmpty(value) ? null : (Object)new Guid(value));
                 }
                 else
                 {


### PR DESCRIPTION
Hi

I noticed that Guids were'nt supported (the Convert.ChangeType doesn't support Guids) so it not attemps to create a Guid from the string. I also noticed a typo and correcte that.

I hope this makes sense.

Regards

Lee
