### PR TITLE
Custom HelpGenerators support

### DIFF
--- a/CLAP/CLAP.csproj
+++ b/CLAP/CLAP.csproj
@@ -84,6 +84,7 @@
   <ItemGroup>
     <Compile Include="CollectionValidationAttribute.cs" />
     <Compile Include="DefaultProvider.cs" />
+    <Compile Include="HelpGeneratorBase.cs" />
     <Compile Include="HelpInfo.cs" />
     <Compile Include="Interception\UserVerbExecutionContext.cs" />
     <Compile Include="Pair.cs" />
@@ -98,7 +99,7 @@
     <Compile Include="EmptyAttribute.cs" />
     <Compile Include="Exceptions.cs" />
     <Compile Include="GlobalAttribute.cs" />
-    <Compile Include="HelpGenerator.cs" />
+    <Compile Include="DefaultHelpGenerator.cs" />
     <Compile Include="Interception\IVerbInterceptor.cs" />
     <Compile Include="Interception\PostVerbExecutionAttribute.cs" />
     <Compile Include="Interception\PostVerbExecutionContext.cs" />

--- a/CLAP/HelpGeneratorBase.cs
+++ b/CLAP/HelpGeneratorBase.cs
@@ -1,0 +1,89 @@
+﻿using System.Collections.Generic;
+
+#if !FW2
+using System.Linq;
+#endif
+
+namespace CLAP
+{
+    public abstract class HelpGeneratorBase
+    {
+        internal string GetHelp(ParserRunner parser)
+        {
+            return GetHelp(new[] { parser });
+        }
+
+        internal string GetHelp(IEnumerable<ParserRunner> parsers)
+        {
+            var help = new HelpInfo {Parsers = parsers.Select(GetParserHelp).ToList()};
+
+            var helpString = GetHelpString(help);
+
+            return helpString;
+        }
+
+        protected abstract string GetHelpString(HelpInfo helpInfo);
+
+        private static ParserHelpInfo GetParserHelp(ParserRunner parser)
+        {
+            var h = new ParserHelpInfo
+            {
+                Type = parser.Type,
+                Verbs = parser.GetVerbs().Select(verb => new VerbHelpInfo
+                {
+                    Names = verb.Names.OrderByDescending(n => n.Length).ToList(),
+                    Description = verb.Description,
+                    IsDefault = verb.IsDefault,
+                    Validations = verb.MethodInfo.GetInterfaceAttributes<ICollectionValidation>().Select(v => v.Description).ToList(),
+                    Parameters = ParserRunner.GetParameters(verb.MethodInfo).
+                        Select(p => new ParameterHelpInfo
+                        {
+                            Required = p.Required,
+                            Names = p.Names.OrderBy(n => n.Length).ToList(),
+                            Type = p.ParameterInfo.ParameterType,
+                            Default = p.DefaultProvider != null ? p.DefaultProvider.Description : p.Default,
+                            Description = p.Description,
+                            Validations = p.ParameterInfo.GetAttributes<ValidationAttribute>().Select(v => v.Description).ToList(),
+                            Separator = p.ParameterInfo.ParameterType.IsArray ?
+                                p.Separator ?? SeparatorAttribute.DefaultSeparator : null,
+                        }).ToList(),
+                }).ToList(),
+                Globals = parser.GetDefinedGlobals().Select(g =>
+                {
+                    var att = g.GetAttribute<GlobalAttribute>();
+                    var parameter = ParserRunner.GetParameters(g).FirstOrDefault();
+
+                    return new GlobalParameterHelpInfo
+                    {
+                        Names = att.Aliases.CommaSplit().Union(new[] { att.Name ?? g.Name }).OrderBy(n => n.Length).ToList(),
+                        Type = parameter != null ? parameter.ParameterInfo.ParameterType : typeof(bool),
+                        Description = att.Description,
+                        Validations = g.GetInterfaceAttributes<ICollectionValidation>().Select(v => v.Description).ToList(),
+                        Separator = parameter != null ?
+                            parameter.ParameterInfo.ParameterType.IsArray ?
+                                parameter.Separator ?? SeparatorAttribute.DefaultSeparator :
+                                    null : null,
+                    };
+                }).Union(parser.Register.RegisteredGlobalHandlers.Values.Select(handler => new GlobalParameterHelpInfo
+                {
+                    Names = handler.Names.OrderBy(n => n.Length).ToList(),
+                    Type = handler.Type,
+                    Description = handler.Description,
+                    Validations = new List<string>(),
+                })).ToList(),
+            };
+
+            if (parser.Register.RegisteredHelpHandlers.Any())
+            {
+                h.Globals.Add(new GlobalParameterHelpInfo
+                {
+                    Names = parser.Register.RegisteredHelpHandlers.Keys.ToList(),
+                    Type = typeof(bool),
+                    Description = "Help",
+                });
+            }
+
+            return h;
+        }
+    }
+}

--- a/CLAP/HelpInfo.cs
+++ b/CLAP/HelpInfo.cs
@@ -3,44 +3,44 @@ using System.Collections.Generic;
 
 namespace CLAP
 {
-    internal class HelpInfo
+    public class HelpInfo
     {
-        internal List<ParserHelpInfo> Parsers { get; set; }
+        public List<ParserHelpInfo> Parsers { get; set; }
     }
 
-    internal class ParserHelpInfo
+    public class ParserHelpInfo
     {
-        internal Type Type { get; set; }
-        internal List<VerbHelpInfo> Verbs { get; set; }
-        internal List<GlobalParameterHelpInfo> Globals { get; set; }
+        public Type Type { get; set; }
+        public List<VerbHelpInfo> Verbs { get; set; }
+        public List<GlobalParameterHelpInfo> Globals { get; set; }
     }
 
-    internal class VerbHelpInfo
+    public class VerbHelpInfo
     {
-        internal bool IsDefault { get; set; }
-        internal string Description { get; set; }
-        internal List<string> Names { get; set; }
-        internal List<ParameterHelpInfo> Parameters { get; set; }
-        internal List<string> Validations { get; set; }
+        public bool IsDefault { get; set; }
+        public string Description { get; set; }
+        public List<string> Names { get; set; }
+        public List<ParameterHelpInfo> Parameters { get; set; }
+        public List<string> Validations { get; set; }
     }
 
-    internal class ParameterHelpInfo
+    public class ParameterHelpInfo
     {
-        internal bool Required { get; set; }
-        internal List<string> Names { get; set; }
-        internal List<string> Validations { get; set; }
-        internal Type Type { get; set; }
-        internal object Default { get; set; }
-        internal string Description { get; set; }
-        internal string Separator { get; set; }
+        public bool Required { get; set; }
+        public List<string> Names { get; set; }
+        public List<string> Validations { get; set; }
+        public Type Type { get; set; }
+        public object Default { get; set; }
+        public string Description { get; set; }
+        public string Separator { get; set; }
     }
 
-    internal class GlobalParameterHelpInfo
+    public class GlobalParameterHelpInfo
     {
-        internal List<string> Names { get; set; }
-        internal List<string> Validations { get; set; }
-        internal Type Type { get; set; }
-        internal string Description { get; set; }
-        internal string Separator { get; set; }
+        public List<string> Names { get; set; }
+        public List<string> Validations { get; set; }
+        public Type Type { get; set; }
+        public string Description { get; set; }
+        public string Separator { get; set; }
     }
 }

--- a/CLAP/MultiParser.cs
+++ b/CLAP/MultiParser.cs
@@ -16,6 +16,7 @@ namespace CLAP
 
         private static readonly string[] s_delimiters = new[] { ".", "/" };
         private readonly Type[] m_types;
+        public HelpGeneratorBase HelpGenerator = new DefaultHelpGenerator();
 
         internal const int ErrorCode = 1;
         internal const int SuccessCode = 0;
@@ -76,7 +77,7 @@ namespace CLAP
             }
             else if (m_types.Length == 1)
             {
-                var parser = new ParserRunner(m_types.First(), Register);
+                var parser = new ParserRunner(m_types.First(), Register, HelpGenerator);
 
                 var target = targets == null ? null : targets[0];
 
@@ -120,7 +121,7 @@ namespace CLAP
                 throw new UnknownParserTypeException(typeName);
             }
 
-            return new ParserRunner(type, registration);
+            return new ParserRunner(type, registration, HelpGenerator);
         }
 
         private ParserRunner GetSingleTypeParser(string[] args, object obj, ParserRegistration registration)
@@ -131,7 +132,7 @@ namespace CLAP
 
             var verb = args[0];
 
-            var parser = new ParserRunner(type, registration);
+            var parser = new ParserRunner(type, registration, HelpGenerator);
 
             // if there is no verb - leave all the args as is
             //
@@ -274,7 +275,7 @@ namespace CLAP
         /// </summary>
         public string GetHelpString()
         {
-            return HelpGenerator.GetHelp(this);
+            return HelpGenerator.GetHelp(Types.Select(t => new ParserRunner(t, Register, HelpGenerator)));
         }
 
         #endregion Public Methods

--- a/CLAP/ParserRunner.cs
+++ b/CLAP/ParserRunner.cs
@@ -20,6 +20,7 @@ namespace CLAP
         private readonly static string s_fileInputSuffix = "@";
 
         private readonly ParserRegistration m_registration;
+        private readonly HelpGeneratorBase m_helpGenerator;
 
         #endregion Fields
 
@@ -36,7 +37,7 @@ namespace CLAP
 
         #region Constructors
 
-        internal ParserRunner(Type type, ParserRegistration parserRegistration)
+        internal ParserRunner(Type type, ParserRegistration parserRegistration, HelpGeneratorBase helpGenerator)
         {
             Debug.Assert(type != null);
 
@@ -45,6 +46,8 @@ namespace CLAP
             m_registration = parserRegistration;
 
             Validate(type, m_registration);
+
+            m_helpGenerator = helpGenerator;
         }
 
         #endregion Constructors
@@ -785,7 +788,7 @@ namespace CLAP
 
             if (helpHandler != null)
             {
-                helpHandler(HelpGenerator.GetHelp(this));
+                helpHandler(m_helpGenerator.GetHelp(this));
 
                 return true;
             }
@@ -807,7 +810,7 @@ namespace CLAP
 
                         var obj = method.IsStatic ? null : target;
 
-                        MethodInvoker.Invoke(method, obj, new[] { HelpGenerator.GetHelp(this) });
+                        MethodInvoker.Invoke(method, obj, new[] { m_helpGenerator.GetHelp(this) });
 
                         return true;
                     }
@@ -848,7 +851,7 @@ namespace CLAP
                 //
                 if (method.HasAttribute<HelpAttribute>())
                 {
-                    var help = HelpGenerator.GetHelp(this);
+                    var help = m_helpGenerator.GetHelp(this);
 
                     // method should execute because it was already passed validation
                     //


### PR DESCRIPTION
Hi Adrian,

The purpose of this change is to allow to format help as user wants. Earlier it was impossible, because the original `HelpGenerator` was a global helper class used throughout the code, so I extracted `HelpGeneratorBase` superclass from default `HelpGenerator`, injected dependencies and changed `*HelpInfo`-classes visibility to public. All tests passed.

Usage example:

``` csharp
class MyHelpGenerator : HelpGeneratorBase
{
    protected override string GetHelpString(HelpInfo helpInfo) { /* ... */ }
}
```

``` csharp
var parser = new Parser<SomeApp> { HelpGenerator = new MyHelpGenerator() };
parser.Run(args, new SomeApp());
```

I hope this makes sense.
