### PR TITLE
Added ability to select preferred verb instead of the first one.

### DIFF
--- a/CLAP/ParserRunner.cs
+++ b/CLAP/ParserRunner.cs
@@ -106,8 +106,7 @@ namespace CLAP
             // find the method by the given verb
             //
             var typeVerbs = GetVerbs()
-                .ToDictionary(v => v, v=>GetParameters(v.MethodInfo).ToList())
-                .ToList();
+                .ToDictionary(v => v, v=>GetParameters(v.MethodInfo).ToList());
 
             // arguments
             var notVerbs = args

--- a/Tests/Samples.cs
+++ b/Tests/Samples.cs
@@ -1469,4 +1469,28 @@ namespace Tests
         {
         }
     }
+
+    public class Sample_74
+    {
+        [Global]
+        public void Bar(string hello)
+        {
+            // hello?
+        }
+
+        [Verb]
+        public void Foo(int a)
+        {
+            IsACalled = true;
+        }
+
+        [Verb]
+        public void Foo(int b, int c)
+        {
+            IsBCalled = true;
+        }
+
+        public bool IsACalled { get; private set; }
+        public bool IsBCalled { get; private set; }
+    }
 }

--- a/Tests/Tests.cs
+++ b/Tests/Tests.cs
@@ -2526,5 +2526,53 @@ namespace Tests
         {
             Parser.Run<Sample_73>(new[] { "foo", "-enums=aaa bbb ccc" });
         }
+
+        [Test]
+        public void Run_preferred_method_for_overload_TestForA()
+        {
+            var sut = new Sample_74();
+            Parser.Run(new[] { "foo", "-a:3" }, sut);
+            Assert.That(sut.IsACalled, Is.True);
+        }
+
+        [Test]
+        public void Run_preferred_method_for_overload_TestForB()
+        {
+            var sut = new Sample_74();
+            Parser.Run(new[] { "foo", "-b:3", "-c:2" }, sut);
+            Assert.That(sut.IsBCalled, Is.True);
+        }
+
+        [Test]
+        public void Run_preferred_method_for_overload_TestForA_WithGlobal()
+        {
+            var sut = new Sample_74();
+            Parser.Run(new[]
+                {
+                    "foo", 
+                    "-a:3", 
+                    "-bar:mike"
+                }, sut);
+            Assert.That(sut.IsACalled, Is.True);
+        }
+
+        [Test]
+        public void Run_preferred_method_for_overload_TestForB_WithGlobal()
+        {
+            var sut = new Sample_74();
+            Parser.Run(new[]
+                {
+                    "foo", 
+                    "-b:3", 
+                    "-c:2", 
+                    "-bar:mike"
+                }, sut);
+            Assert.That(sut.IsBCalled, Is.True);            
+        }
     }
+
+    // Todo: add code to handle overloaded verbs
+    // Todo: - better understand globals and global handlers, see HandleGlobals method
+
+    // Todo: add code to handle sub-commands
 }

--- a/Tests/Tests.cs
+++ b/Tests/Tests.cs
@@ -2570,9 +2570,4 @@ namespace Tests
             Assert.That(sut.IsBCalled, Is.True);            
         }
     }
-
-    // Todo: add code to handle overloaded verbs
-    // Todo: - better understand globals and global handlers, see HandleGlobals method
-
-    // Todo: add code to handle sub-commands
 }


### PR DESCRIPTION
Hi Adrian,

I thought it would be a good feature to be able to use several overloaded verbs and have parser to select preferred one based on the following parameters:
- verb name,
- parameters count,
- and parameter names

I think this can be handy when somebody (like me) needs to execute same verb with different parameters like as follows:
- myexe install /db /u:user /p:password
- myexe install /website
- myexe install /service
- myexe install /etc

I have added code and tests.

Best Regards,
Mikalai Kardash
