### PR TITLE
Allow for localization of description text

### DIFF
--- a/CLAP/GlobalAttribute.cs
+++ b/CLAP/GlobalAttribute.cs
@@ -9,7 +9,7 @@ namespace CLAP
     /// </summary>
     [Serializable]
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
-    public sealed class GlobalAttribute : Attribute
+    public class GlobalAttribute : Attribute
     {
         /// <summary>
         /// The additional aliases (as CSV) of the parameter
@@ -19,7 +19,7 @@ namespace CLAP
         /// <summary>
         /// The description of this parameter
         /// </summary>
-        public string Description { get; set; }
+        public virtual string Description { get; set; }
 
         /// <summary>
         /// The name of this parameter

--- a/CLAP/ParameterAttribute.cs
+++ b/CLAP/ParameterAttribute.cs
@@ -105,9 +105,9 @@ namespace CLAP
     /// </summary>
     [Serializable]
     [AttributeUsage(AttributeTargets.Parameter)]
-    public sealed class DescriptionAttribute : Attribute
+    public class DescriptionAttribute : Attribute
     {
-        public string Description { get; private set; }
+        public virtual string Description { get; private set; }
 
         public DescriptionAttribute(string description)
         {

--- a/CLAP/VerbAttribute.cs
+++ b/CLAP/VerbAttribute.cs
@@ -7,7 +7,7 @@ namespace CLAP
     /// </summary>
     [Serializable]
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
-    public sealed class VerbAttribute : Attribute
+    public class VerbAttribute : Attribute
     {
         /// <summary>
         /// Additional names for the verb
@@ -17,7 +17,7 @@ namespace CLAP
         /// <summary>
         /// The description of the verb. Used to generate the help string
         /// </summary>
-        public string Description { get; set; }
+        public virtual string Description { get; set; }
 
         /// <summary>
         /// Whether this verb is the default verb of the class


### PR DESCRIPTION
My requirement is to be able to localize the descriptions in Verbs and Global parameters. Being able to inherit from these attributes and override the description allows me to use a resource manager (or database/XML whatever) to retrieve the string. This relates to issue #26.

Here is a code sample of how you can use a resource manager (for example) to get the string value:

```
[AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
internal sealed class LocalizedGlobalAttribute : GlobalAttribute
{
  private static readonly ResourceManager Manager = new ResourceManager(typeof(Resources).FullName, typeof(Resources).Assembly);

  public string DescriptionResourceKey { get; set; }

  public override string Description
  {
    get
    {
      if (!string.IsNullOrEmpty(DescriptionResourceKey))
      {
        return Manager.GetString(DescriptionResourceKey, CultureInfo.CurrentCulture);
      }

      return base.Description;
    }
  }
}
```

You would now be able to provide a default description through the normal property as well as a lookup key and get the string using any mechanism you want.
