### PR TITLE
preserve casing when printing help

### DIFF
--- a/CLAP/DefaultHelpGenerator.cs
+++ b/CLAP/DefaultHelpGenerator.cs
@@ -31,10 +31,10 @@ namespace CLAP
 
                     if (multi)
                     {
-                        sb.AppendFormat("{0}.", parser.Type.Name.ToLowerInvariant());
+                        sb.AppendFormat("{0}.", parser.Type.Name);
                     }
 
-                    sb.Append(verb.Names.StringJoin("|").ToLowerInvariant());
+                    sb.Append(verb.Names.StringJoin("|"));
 
                     if (verb.IsDefault)
                     {
@@ -57,7 +57,7 @@ namespace CLAP
                         {
                             sb.Append(parametersLead);
                             sb.AppendFormat("/{0} : ",
-                                p.Names.StringJoin(" /").ToLowerInvariant().PadRight(longestParameter, ' '));
+                                p.Names.StringJoin(" /").PadRight(longestParameter, ' '));
 
                             if (!string.IsNullOrEmpty(p.Description))
                             {
@@ -122,7 +122,7 @@ namespace CLAP
                     {
                         sb.Append(parametersLead);
                         sb.AppendFormat("/{0} : ",
-                            g.Names.StringJoin("|").ToLowerInvariant().PadRight(longestGlobal, ' '));
+                            g.Names.StringJoin("|").PadRight(longestGlobal, ' '));
 
                         if (!string.IsNullOrEmpty(g.Description))
                         {

--- a/CLAP/Method.cs
+++ b/CLAP/Method.cs
@@ -45,7 +45,7 @@ namespace CLAP
             // Names are stored as lower-case.
             // The first available name is the method's original name.
             //
-            Names.Add(method.Name.ToLowerInvariant());
+            Names.Add(method.Name);
 
             MethodInfo = method;
 
@@ -56,7 +56,7 @@ namespace CLAP
 
             if (verbAttribute.Aliases != null)
             {
-                Names.AddRange(verbAttribute.Aliases.ToLowerInvariant().CommaSplit());
+                Names.AddRange(verbAttribute.Aliases.CommaSplit());
             }
         }
 

--- a/CLAP/ParserRunner.cs
+++ b/CLAP/ParserRunner.cs
@@ -128,7 +128,7 @@ namespace CLAP
             // find the method by name, parameter count and parameter names
             var methods = (
                 from v in typeVerbs
-                where v.Key.Names.Contains(verb.ToLowerInvariant())
+                where v.Key.Names.Contains(verb, StringComparer.InvariantCultureIgnoreCase)
                 where v.Value.Count == notVerbs.Count
                 select v
                 ).ToList();
@@ -138,7 +138,7 @@ namespace CLAP
             // if arguments do not match parameter names, exclude globals
             methods = (
                 from v in typeVerbs
-                where v.Key.Names.Contains(verb.ToLowerInvariant())
+                where v.Key.Names.Contains(verb, StringComparer.InvariantCultureIgnoreCase)
                 where v.Value.Count == notVerbsNotGlobals.Count
                 select v
                 ).ToList();
@@ -164,7 +164,7 @@ namespace CLAP
             // if nothing matches...
             if (method == null)
             {
-                method = typeVerbs.FirstOrDefault(v => v.Key.Names.Contains(verb.ToLowerInvariant())).Key;
+                method = typeVerbs.FirstOrDefault(v => v.Key.Names.Contains(verb, StringComparer.InvariantCultureIgnoreCase)).Key;
             }
 
             // if no method is found - a default must exist
@@ -741,9 +741,9 @@ namespace CLAP
             {
                 foreach (var v in verbMethods)
                 {
-                    var c = v.MethodInfo.Name[0].ToString().ToLowerInvariant();
+                    var c = v.MethodInfo.Name[0].ToString();
 
-                    if (!v.Names.Contains(c))
+                    if (!v.Names.Contains(c, StringComparer.InvariantCultureIgnoreCase))
                     {
                         v.Names.Add(c);
                     }


### PR DESCRIPTION
When verb methods/parameters are composed of multiple words (usually with camel/pascal casing), it's hard to read the generated help due to the names being lower-cased.
I modified the code to preserve casing, and to properly compare names while ignoring case.

All tests are passing.
