### PR TITLE
Add Context to DefaultProviderAttribute

### DIFF
--- a/CLAP/DefaultProvider.cs
+++ b/CLAP/DefaultProvider.cs
@@ -12,5 +12,7 @@ namespace CLAP
                 return GetType().Name;
             }
         }
+
+        public string Context { get; internal set; }
     }
 }

--- a/CLAP/Parameter.cs
+++ b/CLAP/Parameter.cs
@@ -74,8 +74,9 @@ namespace CLAP
 
             if (parameter.HasAttribute<DefaultProviderAttribute>())
             {
-                DefaultProvider = (DefaultProvider)Activator.CreateInstance(
-                    parameter.GetAttribute<DefaultProviderAttribute>().DefaultProviderType);
+                DefaultProviderAttribute attribute = parameter.GetAttribute<DefaultProviderAttribute>();
+                DefaultProvider = (DefaultProvider)Activator.CreateInstance(attribute.DefaultProviderType);
+                DefaultProvider.Context = attribute.Context;
             }
 
             if (parameter.HasAttribute<DescriptionAttribute>())

--- a/CLAP/ParameterAttribute.cs
+++ b/CLAP/ParameterAttribute.cs
@@ -70,9 +70,12 @@ namespace CLAP
     {
         public Type DefaultProviderType { get; private set; }
 
-        public DefaultProviderAttribute(Type defaultProviderType)
+        public string Context { get; private set; }
+
+        public DefaultProviderAttribute(Type defaultProviderType, string context = null)
         {
             DefaultProviderType = defaultProviderType;
+            Context = context;
         }
     }
 


### PR DESCRIPTION
New `Context` property for `DefaultProviderAttribute` which gets passed on
to new `Context` property on `DefaultProvider` abstract class.

I added this so that I could determine which property the `DefaultProvider` was being invoked on.  I could not determine that from the `VerbExecutionContext` during `DefaultProvider.GetDefault()`.  Another way could be to add a `Parameter` property to the `VerbExecutionContext` but this way seemed more flexible.  

Now I can use a single `DefaultProvider`-derived class to service many different properties.  In my specific application, I have a verb to set defaults for other verb/parameter combinations and the my `DefaultProvider` checks for a saved default if the parameter isn't supplied on the command line.

_Example attribute usage:_

[DefaultProvider(typeof(ProfileDefaultProvider), "chatId")]

_Example DefaultProvider derived class:_

public class ProfileDefaultProvider : DefaultProvider
{
   public override object GetDefault(VerbExecutionContext context)
   {
      string verb = context.Method.MethodInfo.Name;
      string key = Context;
      return Program.ProfileData.GetVerbData(verb, key);
   }
}
